### PR TITLE
Rework vehicle state getting to be a one-shot operation

### DIFF
--- a/apiscraper.py
+++ b/apiscraper.py
@@ -109,69 +109,77 @@ class StateMonitor(object):
                 logger.info("Waiting %d seconds before retrying." % delay)
                 time.sleep(delay)
 
-    def request_state_group(self, request):
+    def request_state_group(self):
         global a_vin
         global a_displayname
         global a_ignore
-        # Request and process one group of Tesla states.
+        # Request and process all Tesla states
         header_printed = False
         any_change = False
-        logger.info(">> Request Data: " + request)
-        result = self.vehicle.data_request(request)
-        for element in sorted(result):
-            if element not in ("timestamp", "gps_as_of", "left_temp_direction", "right_temp_direction"):
-                old_value = self.old_values[request].get(element, '')
-                new_value = result[element]
-                if ((old_value == '') or ((new_value is not None) and (new_value != old_value))):
-                    logger.info("Value Change, SG: " + request + ": Logging..." + element +
-                                ": old value: " + str(old_value) + ", new value: " + str(new_value))
-                    if not header_printed:
-                        timestamp = None
-                        if "timestamp" in result:
-                            timestamp = result["timestamp"] / 1000
-                        header_printed = True
-                        any_change = True
-                    if new_value != None:
-                        if element not in a_ignore:
-                            json_body = [
-                                {
-                                    "measurement": request,
-                                    "tags": {
-                                        "vin": a_vin,
-                                        "display_name": a_displayname,
-                                        "metric": element
-                                    },
-                                    "time": timestamp * 1000000000,
-                                    "fields": {
-                                        element: new_value
+        logger.info(">> Requesting vehicle data")
+        r = self.vehicle.get("vehicle_data")
+
+        for request in self.requests:
+            result=r['response'][request]
+            for element in sorted(result):
+                if element not in ("timestamp", "gps_as_of", "left_temp_direction", "right_temp_direction"):
+                    old_value = self.old_values[request].get(element, '')
+                    new_value = result[element]
+                    if ((old_value == '') or ((new_value is not None) and (new_value != old_value))):
+                        logger.info("Value Change, SG: " + request + ": Logging..." + element +
+                                    ": old value: " + str(old_value) + ", new value: " + str(new_value))
+                        if not header_printed:
+                            timestamp = None
+                            if "timestamp" in result:
+                                timestamp = result["timestamp"] / 1000
+                            header_printed = True
+                            any_change = True
+                        if new_value != None:
+                            if element not in a_ignore:
+                                json_body = [
+                                    {
+                                        "measurement": request,
+                                        "tags": {
+                                            "vin": a_vin,
+                                            "display_name": a_displayname,
+                                            "metric": element
+                                        },
+                                        "time": timestamp * 1000000000,
+                                        "fields": {
+                                            element: new_value
+                                        }
                                     }
-                                }
-                            ]
-                            influxclient.write_points(json_body)
-                    self.old_values[request][element] = new_value
+                                ]
+                                influxclient.write_points(json_body)
+                        self.old_values[request][element] = new_value
         return any_change
 
     def check_states(self, interval):
         # Check all Tesla States
         any_change = False
-        for request in self.priority_requests.get(interval, self.requests):
-            try:
-                if interval > 32 and (request == "drive_state" or request == "charge_state"):
-                    if self.request_state_group(request):
-                        any_change = True
-                        if request == "drive_state":
-                            interval = 1
-                elif interval <= 32:
-                    if self.request_state_group(request):
-                        any_change = True
-                        if request == "drive_state":
-                            interval = 1
-            except (urllib2.HTTPError, urllib2.URLError) as exc:
-                logger.info("HTTP Error: " + str(exc))
-                if a_allowsleep == 1:
-                    return interval
-                else:
-                    return -1  # re-initialize.
+
+        try:
+            if self.request_state_group():
+                any_change = True
+            else:
+                shift = self.old_values['drive_state'].get('shift_state', '');
+                if shift == "R" or shift == "D":
+                    # We are actively driving, does not matter we are
+                    # stopped at a traffic light or whatnot,
+                    # keep polling
+                    interval = 1
+                    any_change = True
+
+        except (urllib2.HTTPError, urllib2.URLError) as exc:
+            logger.info("HTTP Error: " + str(exc))
+            if a_allowsleep == 1:
+                return interval
+            else:
+                return -1  # re-initialize.
+
+        if interval == 0:
+            interval = 1
+
         if any_change:  # there have been changes, reduce interval
             if interval > 1:
                 interval /= 2
@@ -187,8 +195,11 @@ if __name__ == "__main__":
     asleep_since = 0
     is_asleep = ''
 
-while True:
     vehicle_state = state_monitor.is_asleep()
+while True:
+    # We cannot be sleeping with small poll interval for sure.
+    if poll_interval >= 64:
+        vehicle_state = state_monitor.is_asleep()
     # Car woke up
     if is_asleep == 'asleep' and vehicle_state['state'] == 'online':
         poll_interval = 0
@@ -225,6 +236,8 @@ while True:
     elif poll_interval < 0:
         state_monitor.wake_up()
         poll_interval = 1
+    else:
+        time.sleep(1)
 
     if poll_interval < 512:
         poll_interval = state_monitor.check_states(poll_interval)


### PR DESCRIPTION
using the data_request method forces us to use one RPC per request
which is wasteful and makes us to skip different request types
at the same time, so while we are driving e.g. climate data is
not being updated.
Using vehicle_date request allows us to get all states with a single
request which should be a lot less overhead for us and for Tesla.

the is_asleep still needs to be reworked so we don't create new
connection every time or at least not every time when we are not asleep.

This also adds some logic to keep polling at full speed when the
gear shift is in D or R since even if we are momentarily stopped,
say at a traffic light, we should not really start the slower
polling and potentially miss when we start moving again.

Additionally it remains to be seen if we really can poll this frequently
at 1 request per second or if the car data is fed less frequently to us
for this we really need to look at the timestamps returned and
if the frequence is more rare - adjust?