### PR TITLE
bring up stack with containers

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu:18.04
+
+ARG DATA_PATH
+
+RUN apt-get -y update && apt-get -y install python python-pip
+RUN pip install influxdb
+
+WORKDIR ${DATA_PATH}/tesla-apiscraper
+CMD python apiscraper.py

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,38 @@
+version: '3'
+services:
+   influxdb:
+     image: influxdb:latest
+     container_name: influxdb
+     ports:
+       - "8083:8083"
+       - "8086:8086"
+       - "8090:8090"
+     environment:
+       - "INFLUXDB_DB=tesla"
+       - "INFLUXDB_WRITE_USER=tesla"
+       - "INFLUXDB_WRITE_PASSWORD=tesla"
+     volumes:
+       - ${DATA_PATH}/influxdb:/var/lib/influxdb
+
+   grafana:
+     links:
+       - "influxdb:database"
+     image: grafana/grafana:latest
+     container_name: grafana
+     ports:
+       - "3000:3000"
+     environment:
+       - "GF_INSTALL_PLUGINS=natel-discrete-panel"
+     volumes:
+       - ${DATA_PATH}/grafana:/var/lib/grafana
+       - ./provisioning:/etc/grafana/provisioning/
+       - ../grafana-dashboards/:/var/lib/grafana/dashboards
+
+   apiscraper:
+     network_mode: host
+     build: .
+     container_name: apiscraper
+     volumes:
+       - ${DATA_PATH}:${DATA_PATH}
+     environment:
+       WAIT_HOSTS: influxdb:8086

--- a/docker/provisioning/dashboards/dashboards.yaml
+++ b/docker/provisioning/dashboards/dashboards.yaml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+- name: 'tesla'
+  orgId: 1
+  folder: ''
+  type: file
+  disableDeletion: false
+  updateIntervalSeconds: 10
+  options:
+    path: /var/lib/grafana/dashboards

--- a/docker/provisioning/datasources/datasource.yaml
+++ b/docker/provisioning/datasources/datasource.yaml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: tesla
+    type: influxdb
+    database: tesla
+    user: tesla
+    password: tesla
+    url: http://localhost:8086
+

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+export DATA_PATH=/data
+export BASEDIR=${PWD}
+
+if [[ ! $(docker --version) ]]; then
+  echo "docker is not installed"
+  exit 1
+fi
+
+if [[ ! $(docker-compose --version) ]]; then
+  echo "docker is not installed"
+  exit 1
+fi
+
+if [[ ! -f ../config.py ]]; then
+  echo "please setup your config.py file"
+  exit 1
+fi
+
+if [[ ! -d ${DATA_PATH}/grafana/plugins/grafana-trackmap-panel ]]; then
+  mkdir -p ${DATA_PATH}/grafana/plugins
+  cd ${DATA_PATH}/grafana/plugins/
+  git clone https://github.com/pR0Ps/grafana-trackmap-panel
+  cd ${DATA_PATH}/grafana/plugins/grafana-trackmap-panel
+  git checkout releases
+  chown -R 472:472 ${DATA_PATH}/grafana
+fi
+
+cd ${BASEDIR}
+docker-compose build --build-arg DATA_PATH=${DATA_PATH} apiscraper
+docker-compose up


### PR DESCRIPTION
Quickly bring up all the dependencies with docker-compose.  Grafana doesn't support variables when importing dashboards, so dashboards won't load properly with current version.  Can either change the datasource in the JSON or alter it on the fly.