### PR TITLE
Patch to prevent crashes when hostname lookups fail

### DIFF
--- a/apiscraper.py
+++ b/apiscraper.py
@@ -456,7 +456,10 @@ while True:
         # We cannot be sleeping with small poll interval for sure.
         # In fact can we be sleeping at all if scraping is enabled?
         if poll_interval >= 64 or resume:
-            state_monitor.refresh_vehicle()
+            try:
+                state_monitor.refresh_vehicle()
+            except:
+                logger.info("Hostname Exception Caught")
         # Car woke up
         if is_asleep == 'asleep' and state_monitor.vehicle['state'] == 'online':
             poll_interval = 0


### PR DESCRIPTION
Very basic patch to wrap refresh_vehicle in a try.  This is to prevent the occasionally crash when urllib fails to resolve a hostname.  See issue 45.