### PR TITLE
Missing mapping port 8086 in docker compose for influxdb

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
       - INFLUXDB_DB="tesla"
     volumes:
       - /opt/apiscraper/influxdb:/var/lib/influxdb
+    ports:
+      - "8086:8086"
 
   grafana:
     image: grafana/grafana:latest


### PR DESCRIPTION
Without it, when doing docker-compose up, users will get a connection refused. 