### PR TITLE
Obey a_maximum_sleep config value

### DIFF
--- a/apiscraper.py
+++ b/apiscraper.py
@@ -307,8 +307,10 @@ class StateMonitor(object):
                 if interval > 1:
                     interval /= 2
             else:  # there haven't been any changes, increase interval to allow the car to fall asleep
-                if interval < 2048:
+                if interval < a_maximum_sleep:
                     interval *= 2
+                else:
+                    interval = a_maximum_sleep
         return interval
 
 


### PR DESCRIPTION
Previously the value was ignored and 1024 seconds used. Now the value of
a_maximum_sleep is used instead.