### PR TITLE
Allow charger voltage of 0

### DIFF
--- a/apiscraper.py
+++ b/apiscraper.py
@@ -41,7 +41,7 @@ a_ignore = ["media_state", "software_update", "speed_limit_mode"]
 a_validity_checks = {
     "charger_voltage":
         {
-            "eval": "new_value < 10",
+            "eval": "new_value < 0",
             "set": 0
         }
 }


### PR DESCRIPTION
Tesla Model 3 LR AWD reports a voltage if 0 when not plugged in, so it
is not an invalid value.